### PR TITLE
Fix internal links for GitHub Pages base path

### DIFF
--- a/scripts/make-relative-asset-paths.mjs
+++ b/scripts/make-relative-asset-paths.mjs
@@ -4,6 +4,10 @@ import { dirname, join, relative, resolve, sep } from 'node:path';
 
 const escapeRegex = value => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
+const rawBasePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const normalizedBasePath = rawBasePath.replace(/^\/+|\/+$/g, '');
+const basePathPrefix = normalizedBasePath ? `/${normalizedBasePath}` : '';
+
 const OUT_DIR = resolve(process.cwd(), process.argv[2] ?? 'out');
 
 async function collectHtmlFiles(directory) {
@@ -41,6 +45,14 @@ function normalizeRelativePath(path) {
 
 function rewriteToRelative(content, basePrefix) {
   let result = content;
+  if (basePathPrefix) {
+    const baseWithSlash = `${basePathPrefix}/`;
+    const escapedBaseWithSlash = escapeRegex(baseWithSlash);
+    result = result.replace(
+      new RegExp(`(["'=,(])${escapedBaseWithSlash}`, 'g'),
+      (_, start) => `${start}/`,
+    );
+  }
   const directoryPrefixes = ['_next/', 'images/', 'local-fonts/', 'videos/', 'icons/', 'fonts/'];
   const fileTargets = ['favicon.ico', 'manifest.webmanifest'];
 

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { useState, useEffect } from "react";
 import Image from "next/image";
+import { withBasePath } from "../../utils/basePath";
 
 const NAV_LINKS = [
   { path: "/garage", label: "GARAGE" },
@@ -80,7 +81,12 @@ export default function MyNavbar() {
       <div className="hidden xl:flex w-[85%] h-[1vh] absolute bottom-0 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-[linear-gradient(to_right,transparent,_#97bddc,_#3293e0,_#97bddc,_transparent)]"></div>
       <ul className="hidden xl:flex px-5 w-full h-full justify-around items-center list-none">
         <li className="h-[80%]">
-          <Link href="/" aria-label="Home" className="h-[80%]" onClick={handleClick}>
+          <Link
+            href={withBasePath("/")}
+            aria-label="Home"
+            className="h-[80%]"
+            onClick={handleClick}
+          >
             <div className="aspect-[207/169] h-full">
               <Image
                 src="/images/home/home.webp"
@@ -99,7 +105,7 @@ export default function MyNavbar() {
             className={isActive(path) ? liStyleActive : liStyle}
             aria-current={isActive(path) ? "page" : undefined}
           >
-            <Link href={path}>{label}</Link>
+            <Link href={withBasePath(path)}>{label}</Link>
           </li>
         ))}
         <li className="aspect-[207/169] h-full"></li>
@@ -138,7 +144,7 @@ export default function MyNavbar() {
             </svg>
           </button>
           {/* Center logo */}
-          <Link href="/" className="h-full flex items-center" aria-label="Home">
+          <Link href={withBasePath("/")} className="h-full flex items-center" aria-label="Home">
             <Image
               src="/images/home/tlmoto_principal.webp"
               alt="Home Logo"
@@ -165,7 +171,7 @@ export default function MyNavbar() {
               className={isActive(path) ? liStyleActive : liStyle}
               onClick={() => setIsOpen(false)}
             >
-              <Link href={path}>{label}</Link>
+              <Link href={withBasePath(path)}>{label}</Link>
             </li>
           ))}
         </ul>

--- a/src/components/utils/TransitionLink.tsx
+++ b/src/components/utils/TransitionLink.tsx
@@ -2,6 +2,7 @@
 import Link from "next/link";
 import React, { ComponentProps, ReactNode } from "react";
 import { useRouter } from "next/navigation";
+import { withBasePath } from "../../utils/basePath";
 
 function sleep(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -14,6 +15,7 @@ interface TransitionLinkProps extends ComponentProps<typeof Link> {
 
 export const TransitionLink = ({ children, href, ...props }: TransitionLinkProps) => {
   const router = useRouter();
+  const targetHref = withBasePath(href);
 
   const handleTransition = async (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
@@ -24,7 +26,7 @@ export const TransitionLink = ({ children, href, ...props }: TransitionLinkProps
 
     await sleep(450);
 
-    router.push(href);
+    router.push(targetHref);
 
     await sleep(450);
 
@@ -32,7 +34,7 @@ export const TransitionLink = ({ children, href, ...props }: TransitionLinkProps
   };
 
   return (
-    <Link onClick={handleTransition} href={href} {...props}>
+    <Link onClick={handleTransition} href={targetHref} {...props}>
       {children}
     </Link>
   );

--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -2,6 +2,7 @@
 import MyNavbar from "../components/layout/Navbar";
 import MyFooter from "../components/layout/Footer";
 import Head from "next/head";
+import { withBasePath } from "../utils/basePath";
 
 import { ReactNode } from "react";
 
@@ -11,7 +12,7 @@ export default function Layout({ children }: { children: ReactNode }) {
       <Head>
         <title>TLMOTO</title>
         <meta name="TLMoto Website" content="Created by Software Department" />
-        <link rel="icon" href="/favicon.ico" />
+        <link rel="icon" href={withBasePath("/favicon.ico")} />
       </Head>
       <div className="flex flex-col min-h-screen relative z-20">
         <MyNavbar />

--- a/src/utils/basePath.ts
+++ b/src/utils/basePath.ts
@@ -1,0 +1,25 @@
+const rawBasePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const normalized = rawBasePath.replace(/^\/+|\/+$/g, '');
+
+export const basePath = normalized ? `/${normalized}` : '';
+
+const basePathWithTrailingSlash = basePath ? `${basePath}/` : basePath;
+const ABSOLUTE_PATTERN = /^(?:[a-zA-Z][a-zA-Z\d+\-.]*:|\/\/)/;
+
+export function withBasePath(path: string) {
+  if (!path) {
+    return basePath || '/';
+  }
+
+  if (ABSOLUTE_PATTERN.test(path) || path.startsWith('#')) {
+    return path;
+  }
+
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+
+  if (basePath && normalizedPath.startsWith(basePathWithTrailingSlash)) {
+    return normalizedPath;
+  }
+
+  return `${basePath}${normalizedPath}`;
+}


### PR DESCRIPTION
## Summary
- add a shared helper to compute the configured base path for internal URLs
- update layout navigation and transition links to respect the GitHub Pages subdirectory
- adjust the export rewriting script so relative links stay correct when a base path is provided

## Testing
- npm run lint
