### PR TITLE
Improve offline navigation and asset rewrites

### DIFF
--- a/scripts/make-relative-asset-paths.mjs
+++ b/scripts/make-relative-asset-paths.mjs
@@ -4,6 +4,10 @@ import { dirname, join, relative, resolve, sep } from 'node:path';
 
 const escapeRegex = value => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
+const rawBasePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const normalizedBasePath = rawBasePath.replace(/^\/+|\/+$/g, '');
+const basePathPrefix = normalizedBasePath ? `/${normalizedBasePath}` : '';
+
 const OUT_DIR = resolve(process.cwd(), process.argv[2] ?? 'out');
 
 async function collectHtmlFiles(directory) {
@@ -41,6 +45,14 @@ function normalizeRelativePath(path) {
 
 function rewriteToRelative(content, basePrefix) {
   let result = content;
+  if (basePathPrefix) {
+    const baseWithSlash = `${basePathPrefix}/`;
+    const escapedBaseWithSlash = escapeRegex(baseWithSlash);
+    result = result.replace(
+      new RegExp(`(["'=,(])${escapedBaseWithSlash}`, 'g'),
+      (_, start) => `${start}/`,
+    );
+  }
   const directoryPrefixes = ['_next/', 'images/', 'local-fonts/', 'videos/', 'icons/', 'fonts/'];
   const fileTargets = ['favicon.ico', 'manifest.webmanifest'];
 
@@ -70,7 +82,47 @@ function rewriteToRelative(content, basePrefix) {
   const escapedBasePrefix = escapeRegex(basePrefix);
   result = result.replace(new RegExp(`(href=['"])${escapedBasePrefix}#`, 'g'), '$1#');
 
+  result = result.replace(/(href=(['"]))(\.{1,2}\/[^'"#?]*[^'"#]*)(['"])/g, (match, start, quote, value, end) => {
+    if (!value) {
+      return match;
+    }
+
+    const withoutLeading = value.replace(/^(\.\/|\.\.\/)+/, '');
+
+    if (!withoutLeading) {
+      return `${start}${appendIndexHtml(value)}${end}`;
+    }
+
+    const blockedPrefixes = ['_next/', 'images/', 'local-fonts/', 'videos/', 'icons/', 'fonts/'];
+    const blockedFiles = ['favicon.ico', 'manifest.webmanifest'];
+
+    if (blockedPrefixes.some(prefix => withoutLeading.startsWith(prefix))) {
+      return match;
+    }
+
+    if (blockedFiles.some(file => withoutLeading.startsWith(file))) {
+      return match;
+    }
+
+    return `${start}${appendIndexHtml(value)}${end}`;
+  });
+
   return result;
+}
+
+function appendIndexHtml(value) {
+  const [pathWithQuery, hash = ''] = value.split('#', 2);
+  const [path, query = ''] = pathWithQuery.split('?', 2);
+
+  if (!path || /\.[^/]+$/.test(path)) {
+    return `${path}${query ? `?${query}` : ''}${hash ? `#${hash}` : ''}`;
+  }
+
+  const normalizedPath = path.endsWith('/') ? path : `${path}/`;
+  const querySuffix = query ? `?${query}` : '';
+  const hashSuffix = hash ? `#${hash}` : '';
+
+  return `${normalizedPath}index.html${querySuffix}${hashSuffix}`;
 }
 
 async function main() {

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -3,6 +3,8 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { useState, useEffect } from "react";
 import Image from "next/image";
+import type { AriaAttributes, MouseEventHandler, ReactNode } from "react";
+import { useInternalHref } from "../../utils/useInternalHref";
 
 const NAV_LINKS = [
   { path: "/garage", label: "GARAGE" },
@@ -35,6 +37,10 @@ export default function MyNavbar() {
 
   const handleClick = (e: React.MouseEvent) => {
     if (router.pathname === "/") {
+      if (typeof window !== "undefined" && window.location.protocol === "file:") {
+        return;
+      }
+
       e.preventDefault();
       router.reload();
     }
@@ -80,7 +86,12 @@ export default function MyNavbar() {
       <div className="hidden xl:flex w-[85%] h-[1vh] absolute bottom-0 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-[linear-gradient(to_right,transparent,_#97bddc,_#3293e0,_#97bddc,_transparent)]"></div>
       <ul className="hidden xl:flex px-5 w-full h-full justify-around items-center list-none">
         <li className="h-[80%]">
-          <Link href="/" aria-label="Home" className="h-[80%]" onClick={handleClick}>
+          <InternalNavigationLink
+            path="/"
+            ariaLabel="Home"
+            className="h-[80%]"
+            onClick={handleClick}
+          >
             <div className="aspect-[207/169] h-full">
               <Image
                 src="/images/home/home.webp"
@@ -91,7 +102,7 @@ export default function MyNavbar() {
                 className="h-full w-full transition-transform duration-300 ease-in-out hover:scale-[1.2]"
               />
             </div>
-          </Link>
+          </InternalNavigationLink>
         </li>
         {NAV_LINKS.map(({ path, label }) => (
           <li
@@ -99,7 +110,7 @@ export default function MyNavbar() {
             className={isActive(path) ? liStyleActive : liStyle}
             aria-current={isActive(path) ? "page" : undefined}
           >
-            <Link href={path}>{label}</Link>
+            <InternalNavigationLink path={path}>{label}</InternalNavigationLink>
           </li>
         ))}
         <li className="aspect-[207/169] h-full"></li>
@@ -138,7 +149,7 @@ export default function MyNavbar() {
             </svg>
           </button>
           {/* Center logo */}
-          <Link href="/" className="h-full flex items-center" aria-label="Home">
+          <InternalNavigationLink path="/" className="h-full flex items-center" ariaLabel="Home">
             <Image
               src="/images/home/tlmoto_principal.webp"
               alt="Home Logo"
@@ -147,7 +158,7 @@ export default function MyNavbar() {
               priority
               className="h-[70%] w-auto"
             />
-          </Link>
+          </InternalNavigationLink>
         </div>
         {/* Slide-down Mobile Menu */}
         <ul
@@ -165,7 +176,7 @@ export default function MyNavbar() {
               className={isActive(path) ? liStyleActive : liStyle}
               onClick={() => setIsOpen(false)}
             >
-              <Link href={path}>{label}</Link>
+              <InternalNavigationLink path={path}>{label}</InternalNavigationLink>
             </li>
           ))}
         </ul>
@@ -175,4 +186,50 @@ export default function MyNavbar() {
   function toggleMenu() {
     setIsOpen(prev => !prev);
   }
+}
+
+interface InternalNavigationLinkProps {
+  path: string;
+  className?: string;
+  children: ReactNode;
+  onClick?: MouseEventHandler<HTMLAnchorElement>;
+  ariaLabel?: string;
+  ariaCurrent?: AriaAttributes["aria-current"];
+}
+
+function InternalNavigationLink({
+  path,
+  className,
+  children,
+  onClick,
+  ariaLabel,
+  ariaCurrent,
+}: InternalNavigationLinkProps) {
+  const { href, isFileProtocol } = useInternalHref(path);
+
+  if (isFileProtocol) {
+    return (
+      <a
+        href={href}
+        className={className}
+        aria-label={ariaLabel}
+        aria-current={ariaCurrent}
+        onClick={onClick}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <Link
+      href={href}
+      className={className}
+      aria-label={ariaLabel}
+      aria-current={ariaCurrent}
+      onClick={onClick}
+    >
+      {children}
+    </Link>
+  );
 }

--- a/src/components/utils/TransitionLink.tsx
+++ b/src/components/utils/TransitionLink.tsx
@@ -1,21 +1,33 @@
 "use client";
 import Link from "next/link";
-import React, { ComponentProps, ReactNode } from "react";
+import React, { ReactNode } from "react";
 import { useRouter } from "next/navigation";
+import { useInternalHref } from "../../utils/useInternalHref";
 
 function sleep(ms: number) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-interface TransitionLinkProps extends ComponentProps<typeof Link> {
+interface TransitionLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   children: ReactNode;
   href: string;
 }
 
-export const TransitionLink = ({ children, href, ...props }: TransitionLinkProps) => {
+export const TransitionLink = ({ children, href, onClick, ...props }: TransitionLinkProps) => {
   const router = useRouter();
+  const { href: targetHref, isFileProtocol } = useInternalHref(href);
 
   const handleTransition = async (e: React.MouseEvent<HTMLAnchorElement>) => {
+    onClick?.(e);
+
+    if (e.defaultPrevented) {
+      return;
+    }
+
+    if (isFileProtocol) {
+      return;
+    }
+
     e.preventDefault();
 
     const body = document.querySelector("body");
@@ -24,15 +36,23 @@ export const TransitionLink = ({ children, href, ...props }: TransitionLinkProps
 
     await sleep(450);
 
-    router.push(href);
+    router.push(targetHref);
 
     await sleep(450);
 
     body?.classList.remove("page-transition");
   };
 
+  if (isFileProtocol) {
+    return (
+      <a href={targetHref} onClick={handleTransition} {...props}>
+        {children}
+      </a>
+    );
+  }
+
   return (
-    <Link onClick={handleTransition} href={href} {...props}>
+    <Link onClick={handleTransition} href={targetHref} {...props}>
       {children}
     </Link>
   );

--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -2,16 +2,19 @@
 import MyNavbar from "../components/layout/Navbar";
 import MyFooter from "../components/layout/Footer";
 import Head from "next/head";
+import { useInternalHref } from "../utils/useInternalHref";
 
 import { ReactNode } from "react";
 
 export default function Layout({ children }: { children: ReactNode }) {
+  const { href: faviconHref } = useInternalHref("/favicon.ico");
+
   return (
     <div className="layout">
       <Head>
         <title>TLMOTO</title>
         <meta name="TLMoto Website" content="Created by Software Department" />
-        <link rel="icon" href="/favicon.ico" />
+        <link rel="icon" href={faviconHref} />
       </Head>
       <div className="flex flex-col min-h-screen relative z-20">
         <MyNavbar />

--- a/src/utils/basePath.ts
+++ b/src/utils/basePath.ts
@@ -1,0 +1,25 @@
+const rawBasePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const normalized = rawBasePath.replace(/^\/+|\/+$/g, '');
+
+export const basePath = normalized ? `/${normalized}` : '';
+
+const basePathWithTrailingSlash = basePath ? `${basePath}/` : basePath;
+const ABSOLUTE_PATTERN = /^(?:[a-zA-Z][a-zA-Z\d+\-.]*:|\/\/)/;
+
+export function withBasePath(path: string) {
+  if (!path) {
+    return basePath || '/';
+  }
+
+  if (ABSOLUTE_PATTERN.test(path) || path.startsWith('#')) {
+    return path;
+  }
+
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+
+  if (basePath && normalizedPath.startsWith(basePathWithTrailingSlash)) {
+    return normalizedPath;
+  }
+
+  return `${basePath}${normalizedPath}`;
+}

--- a/src/utils/useInternalHref.ts
+++ b/src/utils/useInternalHref.ts
@@ -1,0 +1,129 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { withBasePath } from './basePath';
+
+const EXPORT_DIR = process.env.NEXT_PUBLIC_EXPORT_DIR ?? 'out';
+const EXPORT_SEGMENT = `/${EXPORT_DIR}/`;
+
+interface HrefState {
+  href: string;
+  isFileProtocol: boolean;
+}
+
+function normalizePath(path: string) {
+  if (!path) {
+    return '/';
+  }
+
+  if (path.startsWith('#')) {
+    return path;
+  }
+
+  return path.startsWith('/') ? path : `/${path}`;
+}
+
+function splitPathQueryHash(value: string) {
+  let path = value;
+  let query = '';
+  let hash = '';
+
+  const hashIndex = path.indexOf('#');
+
+  if (hashIndex !== -1) {
+    hash = path.slice(hashIndex);
+    path = path.slice(0, hashIndex);
+  }
+
+  const queryIndex = path.indexOf('?');
+
+  if (queryIndex !== -1) {
+    query = path.slice(queryIndex);
+    path = path.slice(0, queryIndex);
+  }
+
+  return { path, query, hash };
+}
+
+function computeFileHref(normalizedPath: string) {
+  if (typeof window === 'undefined') {
+    return normalizedPath;
+  }
+
+  if (normalizedPath.startsWith('#')) {
+    return normalizedPath;
+  }
+
+  const { pathname } = window.location;
+  const exportIndex = pathname.indexOf(EXPORT_SEGMENT);
+
+  if (exportIndex === -1) {
+    return normalizedPath;
+  }
+
+  const afterExport = pathname.slice(exportIndex + EXPORT_SEGMENT.length);
+  const currentParts = afterExport.split('/').filter(Boolean);
+
+  if (currentParts.length > 0 && currentParts[currentParts.length - 1].endsWith('.html')) {
+    currentParts.pop();
+  }
+
+  const depth = currentParts.length;
+  const { path, query, hash } = splitPathQueryHash(normalizedPath.replace(/^\/+/, ''));
+  const segments = path.split('/').filter(Boolean);
+  const lastSegment = segments[segments.length - 1];
+  const shouldAppendIndex =
+    path === '' ||
+    path.endsWith('/') ||
+    typeof lastSegment === 'undefined' ||
+    !lastSegment.includes('.');
+
+  let relative = depth === 0 ? './' : '../'.repeat(depth);
+
+  if (segments.length > 0) {
+    if (!relative.endsWith('/')) {
+      relative += '/';
+    }
+
+    relative += segments.join('/');
+  }
+
+  if (shouldAppendIndex) {
+    if (!relative.endsWith('/')) {
+      relative += '/';
+    }
+
+    relative += 'index.html';
+  }
+
+  return `${relative}${query}${hash}`;
+}
+
+export function useInternalHref(path: string): HrefState {
+  const normalizedPath = normalizePath(path);
+  const [state, setState] = useState<HrefState>(() => ({
+    href: withBasePath(normalizedPath),
+    isFileProtocol: false,
+  }));
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (window.location.protocol === 'file:') {
+      setState({
+        href: computeFileHref(normalizedPath),
+        isFileProtocol: true,
+      });
+      return;
+    }
+
+    setState({
+      href: withBasePath(normalizedPath),
+      isFileProtocol: false,
+    });
+  }, [normalizedPath]);
+
+  return state;
+}


### PR DESCRIPTION
## Summary
- add a browser-aware `useInternalHref` helper to calculate base path aware URLs and filesystem-safe fallbacks
- update navigation and transition links to rely on the helper so local file exports keep working while GitHub Pages still receives base-path URLs
- teach the export rewrite script to append `index.html` to internal page links while leaving asset paths untouched

## Testing
- npm run export:relative
- npm run lint
