### PR TITLE
Fix history redirect and background asset path handling

### DIFF
--- a/src/components/DefaultPage.tsx
+++ b/src/components/DefaultPage.tsx
@@ -1,12 +1,15 @@
 import { ReactNode } from "react";
+import { useInternalHref } from "../utils/useInternalHref";
 
 export default function MyDefaultPage({ children }: { children: ReactNode }) {
+  const { href: backgroundHref } = useInternalHref("/images/blue_black_background.webp");
+
   return (
     <div className="relative">
       {/* Background Layer */}
       <div
         className="fixed inset-0 bg-cover bg-center bg-no-repeat bg-fixed z-0"
-        style={{ backgroundImage: 'url("/images/blue_black_background.webp")' }}
+        style={{ backgroundImage: `url('${backgroundHref}')` }}
       ></div>
 
       {/* Foreground Content */}

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -1,18 +1,30 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useRouter } from "next/router";
 import { timelineData } from "@/src/components/textContent/TimelineSectionTexts";
+import { resolveInternalHref } from "../../utils/useInternalHref";
 
 export default function HistoryIndex() {
   const router = useRouter();
-  const years = Object.keys(timelineData)
-    .map(String)
-    .sort((a, b) => Number(a) - Number(b));
+  const years = useMemo(
+    () =>
+      Object.keys(timelineData)
+        .map(String)
+        .sort((a, b) => Number(b) - Number(a)),
+    []
+  );
 
   useEffect(() => {
     if (years.length > 0) {
-      router.replace(`/history/${years[years.length - 1] || years[0]}`); // Redirect to the latest year
+      const latestYear = years[0];
+      const { href, isFileProtocol } = resolveInternalHref(`/history/${latestYear}`);
+
+      if (isFileProtocol) {
+        window.location.href = href;
+      } else {
+        router.replace(href);
+      }
     }
   }, [years, router]);
 
-  return;
+  return null;
 }


### PR DESCRIPTION
## Summary
- ensure the history landing page redirects to the latest season using the internal href resolver so static exports open correctly
- load the shared background image through the internal href hook to restore it when browsing the exported site

## Testing
- npm run lint
