### PR TITLE
Fix static history galleries after relative asset rewriting

### DIFF
--- a/src/components/DefaultPage.tsx
+++ b/src/components/DefaultPage.tsx
@@ -1,12 +1,15 @@
 import { ReactNode } from "react";
+import { useInternalHref } from "../utils/useInternalHref";
 
 export default function MyDefaultPage({ children }: { children: ReactNode }) {
+  const { href: backgroundHref } = useInternalHref("/images/blue_black_background.webp");
+
   return (
     <div className="relative">
       {/* Background Layer */}
       <div
         className="fixed inset-0 bg-cover bg-center bg-no-repeat bg-fixed z-0"
-        style={{ backgroundImage: 'url("/images/blue_black_background.webp")' }}
+        style={{ backgroundImage: `url('${backgroundHref}')` }}
       ></div>
 
       {/* Foreground Content */}

--- a/src/pages/history/[year].tsx
+++ b/src/pages/history/[year].tsx
@@ -6,19 +6,17 @@ import { useRouter } from "next/router";
 import TiltedCard from "@/src/components/extras/TiltedCard";
 import { motion, AnimatePresence } from "framer-motion";
 
+type TimelineEventWithImages = TimelineDataItem & { images: string[] };
+
 export async function getStaticProps({ params }: { params: { year: string } }) {
   const { year } = params;
 
-  const events = timelineData[year] || [];
-  const yearData = events.reduce(
-    (acc, event) => {
-      acc[event.imageFolder] = getImages(event.imageFolder);
-      return acc;
-    },
-    {} as Record<string, string[]>
-  );
+  const events: TimelineEventWithImages[] = (timelineData[year] || []).map(event => ({
+    ...event,
+    images: getImages(event.imageFolder),
+  }));
 
-  return { props: { yearData, selectedYear: year } };
+  return { props: { events, selectedYear: year } };
 }
 
 export async function getStaticPaths() {
@@ -34,10 +32,10 @@ export async function getStaticPaths() {
 }
 
 export default function History({
-  yearData,
+  events,
   selectedYear,
 }: {
-  yearData: { [key: string]: string[] };
+  events: TimelineEventWithImages[];
   selectedYear: string;
 }) {
   // inside History component
@@ -255,12 +253,12 @@ export default function History({
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5 }}
         >
-          {timelineData[selectedYear].map((item: TimelineDataItem) => (
+          {events.map(item => (
             <div key={item.title} className="mt-[2.5vh] mb-[2.5vh] lg:mb-[0vh] xl:mb-[10vh]">
               <h3 className="text-4xl font-bold mb-[0.125vh]">{item.title}</h3>
               <p className="text-xl mb-[2vh]">{item.description}</p>
               <div className="grid grid-cols-2 gap-y-[1.5vh] justify-items-center md:grid-cols-3 lg:gap-x-[1.5vw] lg:gap-y-[1.5vh] lg:grid-cols-4 xl:gap-x-[2vw] xl:gap-y-[2vh]">
-                {yearData[item.imageFolder].map((element: string) => (
+                {item.images.map((element: string) => (
                   <div key={element} onClick={() => setFullscreenImage(element)}>
                     <TiltedCard
                       imageSrc={element}

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -1,18 +1,30 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useRouter } from "next/router";
 import { timelineData } from "@/src/components/textContent/TimelineSectionTexts";
+import { resolveInternalHref } from "../../utils/useInternalHref";
 
 export default function HistoryIndex() {
   const router = useRouter();
-  const years = Object.keys(timelineData)
-    .map(String)
-    .sort((a, b) => Number(a) - Number(b));
+  const years = useMemo(
+    () =>
+      Object.keys(timelineData)
+        .map(String)
+        .sort((a, b) => Number(b) - Number(a)),
+    []
+  );
 
   useEffect(() => {
     if (years.length > 0) {
-      router.replace(`/history/${years[years.length - 1] || years[0]}`); // Redirect to the latest year
+      const latestYear = years[0];
+      const { href, isFileProtocol } = resolveInternalHref(`/history/${latestYear}`);
+
+      if (isFileProtocol) {
+        window.location.href = href;
+      } else {
+        router.replace(href);
+      }
     }
   }, [years, router]);
 
-  return;
+  return null;
 }


### PR DESCRIPTION
## Summary
- include pre-computed history events with their image lists in the page props so the relative export rewrite no longer breaks the lookup keys
- render the history gallery from the provided events array to avoid undefined map errors in exported builds

## Testing
- npm run lint
- npm run export:relative
