### PR TITLE
Fix runtime base path resolution for relative exports

### DIFF
--- a/src/components/garage/GarageCards.tsx
+++ b/src/components/garage/GarageCards.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { cards } from "src/components/textContent/GarageSectionTexts";
 import { TransitionLink } from "../utils/TransitionLink";
 import { motion } from "framer-motion";
+import { withBasePath } from "@/src/utils/basePath";
 
 export default function MyGarageCards() {
   const DESKTOP_VISIBLE = 3;
@@ -85,7 +86,7 @@ export default function MyGarageCards() {
   return (
     <div className="relative w-full h-screen flex items-center justify-center overflow-hidden">
       <video autoPlay muted className="fixed top-0 left-0 w-full h-full object-cover z-[-1]">
-        <source src="/videos/garage/garage_menu.mp4" type="video/mp4" />
+        <source src={withBasePath("/videos/garage/garage_menu.mp4")} type="video/mp4" />
       </video>
 
       <div className="relative w-full max-w-6xl p-6">

--- a/src/components/homePage/AboutSection.tsx
+++ b/src/components/homePage/AboutSection.tsx
@@ -9,6 +9,7 @@ import {
   useMotionValueEvent,
   animate,
 } from "framer-motion";
+import { withBasePath } from "@/src/utils/basePath";
 
 const containerVariants = {
   hidden: {},
@@ -64,6 +65,9 @@ const AboutSection: React.FC = () => {
     { icon: <Lightbulb />, title: "Prototypes", to: 4, suffix: "+", delay: 0.4 },
   ] as const;
 
+  const backgroundRelative = "/images/home/team_background.webp";
+  const backgroundSrc = withBasePath(backgroundRelative);
+
   return (
     <motion.section
       id="section2"
@@ -79,7 +83,7 @@ const AboutSection: React.FC = () => {
           filter
           -z-10
         `}
-        style={{ backgroundImage: "url('/images/home/team_background.webp')" }}
+        style={{ backgroundImage: `url('${backgroundSrc}')` }}
       />
       <div className="absolute inset-0 bg-black/60 pointer-events-none z-0" />
 

--- a/src/components/homePage/CompetitionSection.tsx
+++ b/src/components/homePage/CompetitionSection.tsx
@@ -4,6 +4,7 @@ import { Trophy, MapPin, Calendar, Users, ArrowRight } from "lucide-react";
 import Image from "next/image";
 import { motion } from "framer-motion";
 import { TransitionLink } from "../utils/TransitionLink";
+import { withBasePath } from "@/src/utils/basePath";
 
 const containerVariants = {
   hidden: {},
@@ -51,6 +52,9 @@ const CompetitionsSection = () => {
     },
   ];
 
+  const backgroundRelative = "/images/home/aragon_background.webp";
+  const backgroundSrc = withBasePath(backgroundRelative);
+
   return (
     <motion.section
       id="section3"
@@ -58,7 +62,7 @@ const CompetitionsSection = () => {
       whileInView="visible"
       viewport={{ once: false, amount: 0.3 }}
       className={`bg-no-repeat bg-cover bg-center ${sectionStyle}`}
-      style={{ backgroundImage: `url('/images/home/aragon_background.webp')` }}
+      style={{ backgroundImage: `url('${backgroundSrc}')` }}
     >
       <div className="absolute inset-0 bg-black/40 pointer-events-none z-0" />
       <div
@@ -103,7 +107,7 @@ const CompetitionsSection = () => {
           <div className="animate-slide-in-left">
             <div className="relative rounded-2xl overflow-hidden group">
               <Image
-                src="/images/home/aragon_background.webp"
+                src={backgroundRelative}
                 width={600}
                 height={500}
                 alt="Racing Competition"

--- a/src/components/homePage/HeroSection.tsx
+++ b/src/components/homePage/HeroSection.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { ChevronDown } from "lucide-react";
 import { motion } from "framer-motion";
 import Image from "next/image";
+import { withBasePath } from "@/src/utils/basePath";
 
 const HeroSection = () => {
   const [showVideo, setShowVideo] = useState(false);
@@ -25,6 +26,11 @@ const HeroSection = () => {
     }
   };
 
+  const posterRelative = "/images/home/moto_blue_black_background.webp";
+  const videoRelative = "/videos/intro_video_background.mp4";
+  const posterSrc = withBasePath(posterRelative);
+  const videoSrc = withBasePath(videoRelative);
+
   return (
     <motion.section
       id="section1"
@@ -41,14 +47,14 @@ const HeroSection = () => {
           autoPlay
           playsInline
           disablePictureInPicture
-          poster="/images/home/moto_blue_black_background.webp"
+          poster={posterSrc}
         >
-          <source src="/videos/intro_video_background.mp4" type="video/mp4" />
+          <source src={videoSrc} type="video/mp4" />
         </video>
       ) : (
         <div className="hidden xl:block absolute inset-0 w-full h-full z-0">
           <Image
-            src="/images/home/moto_blue_black_background.webp"
+            src={posterRelative}
             alt="TLMoto background"
             fill
             style={{ objectFit: "cover" }}
@@ -60,7 +66,7 @@ const HeroSection = () => {
       )}
       <div
         className="block xl:hidden absolute inset-0 w-full h-full bg-no-repeat bg-cover bg-center z-0"
-        style={{ backgroundImage: "url('/images/home/moto_blue_black_background.webp')" }}
+        style={{ backgroundImage: `url('${posterSrc}')` }}
       />
       {/* Main content */}
       <button

--- a/src/components/homePage/PrototypeSection.tsx
+++ b/src/components/homePage/PrototypeSection.tsx
@@ -1,5 +1,6 @@
 import { motion } from "framer-motion";
 import dynamic from "next/dynamic";
+import { withBasePath } from "@/src/utils/basePath";
 
 const MotorbikeCarousel = dynamic(() => import("./MotorbikeCarousel"), {
   ssr: false,
@@ -30,6 +31,9 @@ const sectionStyle =
   "relative";
 
 export const PrototypesSection = () => {
+  const backgroundRelative = "/images/home/prototype_background.webp";
+  const backgroundSrc = withBasePath(backgroundRelative);
+
   return (
     <motion.section
       id="section4"
@@ -37,7 +41,7 @@ export const PrototypesSection = () => {
       whileInView="visible"
       viewport={{ once: false, amount: 0.25 }}
       className={`bg-no-repeat bg-cover bg-center ${sectionStyle}`}
-      style={{ backgroundImage: `url('/images/home/prototype_background.webp')` }}
+      style={{ backgroundImage: `url('${backgroundSrc}')` }}
     >
       <div className="absolute inset-0 bg-black/40 pointer-events-none z-0" />
 

--- a/src/components/homePage/SponsorSection.tsx
+++ b/src/components/homePage/SponsorSection.tsx
@@ -1,11 +1,15 @@
 import React from "react";
 import InfiniteLogoCarousel from "./InfiniteLogoCarousel";
+import { withBasePath } from "@/src/utils/basePath";
 
 const SponsorsCarousel: React.FC = () => {
+  const backgroundRelative = "/images/home/aragon_background.webp";
+  const backgroundSrc = withBasePath(backgroundRelative);
+
   return (
     <section
       className="py-20 relative overflow-hidden bg-no-repeat bg-cover bg-center"
-      style={{ backgroundImage: "url('/images/home/aragon_background.webp')" }}
+      style={{ backgroundImage: `url('${backgroundSrc}')` }}
     >
       <div className="absolute inset-0 bg-black/40 pointer-events-none z-0" />
       <div

--- a/src/components/news/NewsCoverflowEffect.tsx
+++ b/src/components/news/NewsCoverflowEffect.tsx
@@ -1,6 +1,13 @@
 import React, { useEffect, useState, useCallback } from "react";
 import Image from "next/image";
 import { motion } from "framer-motion";
+import { withBasePath } from "@/src/utils/basePath";
+
+const PLACEHOLDER_IMAGE = withBasePath("/images/newsletter/placeholder.jpg");
+
+function buildNewsletterImagePath(year: string, name: string) {
+  return withBasePath(`/images/newsletter/${year}/${name}`);
+}
 
 interface Newsletter {
   name: string;
@@ -309,7 +316,7 @@ export default function MyNewsCoverflowEffect({ onSubscribeClick }: MyNewsCoverf
             allNewsletters.push({
               ...newsletter,
               year: year,
-              fullPath: `/images/newsletter/${year}/${newsletter.name}`,
+              fullPath: buildNewsletterImagePath(year, newsletter.name),
               link: newsletter.link, // Usar o link específico de cada newsletter
             });
           });
@@ -326,7 +333,7 @@ export default function MyNewsCoverflowEffect({ onSubscribeClick }: MyNewsCoverf
         return (newsletterData[selectedYear] || []).map(newsletter => ({
           ...newsletter,
           year: selectedYear,
-          fullPath: `/images/newsletter/${selectedYear}/${newsletter.name}`,
+          fullPath: buildNewsletterImagePath(selectedYear, newsletter.name),
           link: newsletter.link, // Usar o link específico de cada newsletter
         }));
       }
@@ -461,7 +468,7 @@ export default function MyNewsCoverflowEffect({ onSubscribeClick }: MyNewsCoverf
           .map(newsletter => ({
             ...newsletter,
             year: year,
-            fullPath: `/images/newsletter/${year}/${newsletter.name}`,
+            fullPath: buildNewsletterImagePath(year, newsletter.name),
             link: newsletter.link,
             linkPt: newsletter.linkPt,
           }));
@@ -710,7 +717,7 @@ export default function MyNewsCoverflowEffect({ onSubscribeClick }: MyNewsCoverf
                     className="object-contain transition-transform duration-300 group-hover:scale-110"
                     onError={e => {
                       const target = e.target as HTMLImageElement;
-                      target.src = "/images/newsletter/placeholder.jpg";
+                      target.src = PLACEHOLDER_IMAGE;
                     }}
                   />
 
@@ -759,7 +766,7 @@ export default function MyNewsCoverflowEffect({ onSubscribeClick }: MyNewsCoverf
                   className="object-contain transition-transform duration-300 group-hover:scale-110"
                   onError={e => {
                     const target = e.target as HTMLImageElement;
-                    target.src = "/images/newsletter/placeholder.jpg";
+                    target.src = PLACEHOLDER_IMAGE;
                   }}
                 />
 
@@ -829,7 +836,7 @@ export default function MyNewsCoverflowEffect({ onSubscribeClick }: MyNewsCoverf
                       className="object-contain transition-transform duration-300 group-hover:scale-110"
                       onError={e => {
                         const target = e.target as HTMLImageElement;
-                        target.src = "/images/newsletter/placeholder.jpg";
+                        target.src = PLACEHOLDER_IMAGE;
                       }}
                     />
 

--- a/src/components/textContent/GarageSectionTexts.tsx
+++ b/src/components/textContent/GarageSectionTexts.tsx
@@ -1,4 +1,6 @@
-export const cards = [
+import { withBasePath } from "@/src/utils/basePath";
+
+const cardData = [
   {
     id: "m01",
     imageSrc: "/images/garage/01.webp",
@@ -79,7 +81,13 @@ export const cards = [
   },
 ];
 
-export const backgrounds = {
+export const cards = cardData.map(card => ({
+  ...card,
+  imageSrc: withBasePath(card.imageSrc),
+  video: withBasePath(card.video),
+}));
+
+const backgroundData = {
   m01: ["/videos/garage/details/desktop/m01.mp4"],
   m02: ["/videos/garage/details/desktop/sun/m02_sun.mp4"],
   m03: [
@@ -92,7 +100,11 @@ export const backgrounds = {
     "/videos/garage/details/desktop/gulf/m04_gulf.mp4",
     "/videos/garage/details/desktop/bordeaux/m04_bordeaux.mp4",
   ],
-};
+} as const;
+
+export const backgrounds = Object.fromEntries(
+  Object.entries(backgroundData).map(([key, values]) => [key, values.map(withBasePath)])
+) as Record<keyof typeof backgroundData, string[]>;
 
 export const themeColors = {
   m01: "0,82,212", // azul

--- a/src/components/utils/FetchFolderImages.tsx
+++ b/src/components/utils/FetchFolderImages.tsx
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import { withBasePath } from "@/src/utils/basePath";
 
 const TEAM_DIR = path.join(process.cwd(), "public/images/team");
 const TEAM_DATA_DIR = path.join(process.cwd(), "src/components/textContent/team");
@@ -28,7 +29,9 @@ export function getTeamMembersWithLinkedIn(year: string) {
 
   let teampic = "";
   if (pathpics.length > 0)
-    teampic = `/images/team/${year}/${encodeURIComponent(pathpics[0].normalize("NFC"))}`;
+    teampic = withBasePath(
+      `/images/team/${year}/${encodeURIComponent(pathpics[0].normalize("NFC"))}`
+    );
 
   let teamData: Record<
     string,
@@ -52,8 +55,12 @@ export function getTeamMembersWithLinkedIn(year: string) {
         .filter((member: { image: string }) => member.image && member.image !== "")
         .map(member => ({
           name: member.name,
-          image: `/images/team/${year}/${encodeURIComponent(category.normalize("NFC"))}/${encodeURIComponent(member.image)}`,
-          cardImage: `/images/team/${year}/${encodeURIComponent(category.normalize("NFC"))}/${encodeURIComponent(member.cardImage)}`,
+          image: withBasePath(
+            `/images/team/${year}/${encodeURIComponent(category.normalize("NFC"))}/${encodeURIComponent(member.image)}`
+          ),
+          cardImage: withBasePath(
+            `/images/team/${year}/${encodeURIComponent(category.normalize("NFC"))}/${encodeURIComponent(member.cardImage)}`
+          ),
           linkedin: member.linkedin || null,
         }));
 
@@ -81,5 +88,5 @@ export function getImages(folderPath: string): string[] {
     .readdirSync(absPath, { encoding: "utf8" })
     .filter(file => /\.webp$/i.test(file))
     .sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" }))
-    .map(file => path.posix.join("/", folderPath, file)); // URL-friendly path
+    .map(file => withBasePath(path.posix.join("/", folderPath, file))); // URL-friendly path
 }

--- a/src/pages/garage/[id].tsx
+++ b/src/pages/garage/[id].tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react";
 import { cards, backgrounds } from "src/components/textContent/GarageSectionTexts";
 import MyStatsChart from "src/components/garage/GarageStatsChart";
 import { motion } from "framer-motion";
+import { withBasePath } from "@/src/utils/basePath";
 
 type Card = (typeof cards)[number];
 
@@ -28,7 +29,9 @@ export default function GarageDetailPage({ card }: GarageDetailPageProps) {
   const motoBackgrounds = backgrounds[card.id as keyof typeof backgrounds] ?? [card.video];
   const currentVideo = motoBackgrounds[bgIndex];
 
-  const motoImage = `/images/garage/${card.id.replace("m", "").padStart(2, "0")}.webp`;
+  const motoImage = withBasePath(
+    `/images/garage/${card.id.replace("m", "").padStart(2, "0")}.webp`
+  );
 
   const toggleBackground = () => {
     if (motoBackgrounds.length > 1) {

--- a/src/utils/basePath.ts
+++ b/src/utils/basePath.ts
@@ -3,23 +3,93 @@ const normalized = rawBasePath.replace(/^\/+|\/+$/g, '');
 
 export const basePath = normalized ? `/${normalized}` : '';
 
-const basePathWithTrailingSlash = basePath ? `${basePath}/` : basePath;
 const ABSOLUTE_PATTERN = /^(?:[a-zA-Z][a-zA-Z\d+\-.]*:|\/\/)/;
+const NEXT_STATIC_SEGMENT = '_next/static/';
+
+type GlobalWithPrefixCache = typeof globalThis & {
+  __TL_RUNTIME_ASSET_PREFIX__?: string;
+};
+
+let cachedRuntimePrefix: string | undefined;
+
+function normalizePrefix(prefix: string | undefined) {
+  if (!prefix) {
+    return '/';
+  }
+
+  if (prefix === '.') {
+    return './';
+  }
+
+  return prefix;
+}
+
+function getRuntimePrefix() {
+  if (typeof window === 'undefined') {
+    return basePath || '/';
+  }
+
+  if (cachedRuntimePrefix !== undefined) {
+    return cachedRuntimePrefix;
+  }
+
+  const globalScope = globalThis as GlobalWithPrefixCache;
+
+  if (typeof globalScope.__TL_RUNTIME_ASSET_PREFIX__ === 'string') {
+    cachedRuntimePrefix = globalScope.__TL_RUNTIME_ASSET_PREFIX__;
+    return cachedRuntimePrefix;
+  }
+
+  let prefix = basePath;
+
+  if (!prefix) {
+    const script = document.querySelector<HTMLScriptElement>('script[src*="_next/static/"]');
+
+    if (script) {
+      const src = script.getAttribute('src') ?? '';
+      const markerIndex = src.indexOf(NEXT_STATIC_SEGMENT);
+
+      if (markerIndex !== -1) {
+        prefix = src.slice(0, markerIndex);
+      }
+    }
+  }
+
+  cachedRuntimePrefix = normalizePrefix(prefix);
+  globalScope.__TL_RUNTIME_ASSET_PREFIX__ = cachedRuntimePrefix;
+
+  return cachedRuntimePrefix;
+}
+
+function joinPrefix(prefix: string, targetPath: string) {
+  const trimmedPath = targetPath.startsWith('/') ? targetPath.slice(1) : targetPath;
+
+  if (!trimmedPath) {
+    return prefix || '/';
+  }
+
+  if (!prefix || prefix === '/') {
+    return `/${trimmedPath}`;
+  }
+
+  return prefix.endsWith('/') ? `${prefix}${trimmedPath}` : `${prefix}/${trimmedPath}`;
+}
 
 export function withBasePath(path: string) {
   if (!path) {
-    return basePath || '/';
+    return getRuntimePrefix();
   }
 
   if (ABSOLUTE_PATTERN.test(path) || path.startsWith('#')) {
     return path;
   }
 
+  const prefix = getRuntimePrefix();
   const normalizedPath = path.startsWith('/') ? path : `/${path}`;
 
-  if (basePath && normalizedPath.startsWith(basePathWithTrailingSlash)) {
+  if (basePath && normalizedPath.startsWith(`${basePath}/`)) {
     return normalizedPath;
   }
 
-  return `${basePath}${normalizedPath}`;
+  return joinPrefix(prefix, normalizedPath);
 }


### PR DESCRIPTION
## Summary
- derive the runtime asset prefix from the Next.js static script tag when no base path is configured
- cache the detected prefix so client-side renders keep relative asset URLs consistent during hydration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e13309b6108326b045b17c517ba778